### PR TITLE
feat(1961): Trigger npm publish. BREAKING CHANGE: bump major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-request",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Wrapper around got pkg to define a simple interface for http requests",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context

Last merge failed to publish new NPM package.
## Objective

This PR will trigger a major version bump.
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
