### PR TITLE
fix: Do not force bearer token, allow basic auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,15 +24,7 @@ const got = Got.extend({
         (options, next) => {
             const { token, caller } = options.context;
 
-            // Check auth token
-            if (!token && !options.headers.authorization) {
-                const errorCode = 403;
-                const errorReason = 'Missing token for authentication';
-
-                throwError({ errorCode, errorReason, caller });
-            }
-
-            // Default to seting bearer token
+            // Default to setting bearer token
             if (token && !options.headers.authorization) {
                 options.headers.authorization = `Bearer ${token}`;
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,24 +48,6 @@ describe('index', function() {
             nock.cleanAll();
         });
 
-        it('throws when missing token', () => {
-            return got({
-                method: 'GET',
-                url: `${prefixUrl}/${route}`,
-                context: {
-                    caller: '_getProject'
-                }
-            })
-                .then(() => {
-                    assert.fail('should not get here');
-                })
-                .catch(error => {
-                    assert.instanceOf(error, Error);
-                    assert.match(error.message, '403 Reason "Missing token for authentication" Caller "_getProject"');
-                    assert.match(error.status, 403);
-                });
-        });
-
         it('sets token successfully', () => {
             nock(prefixUrl, {
                 reqheaders: {


### PR DESCRIPTION
## Context

Calls to Sonar are failing since it uses basic auth vs this package expects bearer token.

## Objective

This PR no longer throws error when missing bearer token.

## References
N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
