### PR TITLE
fix: Use err.statusCode

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const Hoek = require('@hapi/hoek');
 function throwError({ errorCode, errorReason, caller }) {
     const err = new Error(`${errorCode} Reason "${errorReason}" Caller "${caller}"`);
 
-    err.status = errorCode;
+    err.statusCode = errorCode;
     throw err;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -97,7 +97,7 @@ describe('index', function() {
                 .catch(error => {
                     assert.instanceOf(error, Error);
                     assert.match(error.message, '500 Reason "Internal Server Error" Caller "_getProject"');
-                    assert.match(error.status, 500);
+                    assert.match(error.statusCode, 500);
                 });
         });
     });


### PR DESCRIPTION
## Context

Many repos expect error object to have `statusCode` field. Would be better to stick to that convention.
## Objective

This PR changes `err.status` to `err.statusCode`.
## References

N/A
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
