### PR TITLE
fix: do not allow get body

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const Hoek = require('@hapi/hoek');
  * @param  {String} caller      Name of method or call that caused the error
  * @return {Error}              Throws prettified error
  */
-function throwError({ errorCode, errorReason, caller }) {
-    const err = new Error(`${errorCode} Reason "${errorReason}" Caller "${caller}"`);
+function throwError({ errorCode, errorReason }) {
+    const err = new Error(`${errorCode} Reason "${errorReason}"`);
 
     err.statusCode = errorCode;
     throw err;
@@ -21,7 +21,7 @@ const got = Got.extend({
     responseType: 'json',
     handlers: [
         (options, next) => {
-            const { token, caller } = options.context;
+            const { token } = options.context;
 
             // Default to setting bearer token
             if (token && !options.headers.authorization) {
@@ -53,7 +53,7 @@ const got = Got.extend({
                         });
                     }
 
-                    return throwError({ errorCode, errorReason, caller });
+                    return throwError({ errorCode, errorReason });
                 }
             })();
         }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ function throwError({ errorCode, errorReason, caller }) {
 
 const got = Got.extend({
     responseType: 'json',
-    allowGetBody: true, // Allow us to pass prefixUrl, token, etc
     handlers: [
         (options, next) => {
             const { token, caller } = options.context;
@@ -47,7 +46,7 @@ const got = Got.extend({
 
                     if (response) {
                         errorCode = Hoek.reach(response, 'statusCode', {
-                            default: 'Service unavailable.'
+                            default: errorCode
                         });
                         errorReason = Hoek.reach(response, 'body.message', {
                             default: JSON.stringify(response.body)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,6 @@ describe('index', function() {
                 method: 'GET',
                 url: `${prefixUrl}/${route}`,
                 context: {
-                    caller: '_getProject',
                     token
                 }
             })
@@ -96,7 +95,7 @@ describe('index', function() {
                 })
                 .catch(error => {
                     assert.instanceOf(error, Error);
-                    assert.match(error.message, '500 Reason "Internal Server Error" Caller "_getProject"');
+                    assert.match(error.message, '500 Reason "Internal Server Error"');
                     assert.match(error.statusCode, 500);
                 });
         });


### PR DESCRIPTION
## Context

Should not need to `allowGetBody`.

## Objective

This PR removes `allowGetBody` and fixes default `errorCode`.

## References

Related to https://github.com/screwdriver-cd/scm-gitlab/pull/45

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
