### PR TITLE
[1] feat: add err.code

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,7 +71,7 @@ describe('index', function() {
             });
         });
 
-        it('throws when get error code not in range', () => {
+        it('throws when get error statusCode not in range', () => {
             nock(prefixUrl, {
                 reqheaders: {
                     authorization: headerValue => headerValue.includes('Bearer ')
@@ -97,6 +97,35 @@ describe('index', function() {
                     assert.instanceOf(error, Error);
                     assert.match(error.message, '500 Reason "Internal Server Error"');
                     assert.match(error.statusCode, 500);
+                });
+        });
+
+        it('throws with right error code', () => {
+            nock(prefixUrl, {
+                reqheaders: {
+                    authorization: headerValue => headerValue.includes('Bearer ')
+                }
+            })
+                .get(`/${route}`)
+                .delayConnection(500)
+                .reply(200, result)
+                .persist();
+
+            return got({
+                method: 'GET',
+                url: `${prefixUrl}/${route}`,
+                context: {
+                    caller: '_getProject',
+                    token
+                },
+                timeout: 400
+            })
+                .then(() => {
+                    assert.fail('should not get here');
+                })
+                .catch(error => {
+                    assert.instanceOf(error, Error);
+                    assert.match(error.code, 'ETIMEDOUT');
                 });
         });
     });


### PR DESCRIPTION
## Context
If a request does not return a response (e.g. times out), no information is returned on how it failed.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When it returns an error, the status (e.g. ETIMEDOUT) is put in `err.code`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[got/error](https://github.com/sindresorhus/got/blob/main/documentation/8-errors.md)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
